### PR TITLE
fix: Bump the platform minimum versions to match Pulse dependency

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,17 +5,17 @@ import PackageDescription
 let package = Package(
     name: "PulseLogHandler",
     platforms: [
-        .iOS(.v13),
-        .tvOS(.v13),
-        .macOS(.v11),
-        .watchOS(.v7)
+        .iOS(.v14),
+        .tvOS(.v14),
+        .macOS(.v12),
+        .watchOS(.v8)
     ],
     products: [
         .library(name: "PulseLogHandler", targets: ["PulseLogHandler"])
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-log.git", from: "1.2.0"),
-        .package(url: "https://github.com/kean/pulse.git", from: "3.0.0")
+        .package(url: "https://github.com/kean/pulse.git", from: "3.1.0")
     ],
     targets: [
         .target(name: "PulseLogHandler", dependencies: [


### PR DESCRIPTION
The minimum target for Pulse is `iOS 14.0` but for PulseLogHandler is `iOS 13.0`, PulseLogHandler depends upon Pulse and therefore cannot be built, this PR bumps the platform versions for PulseLogHandler to match it's dependency

> ```
> error: The package product 'Pulse' requires minimum platform version 14.0 for the iOS platform, but this target supports 13.0 (in target 'PulseLogHandler' from project 'PulseLogHandler')
> ```