### PR TITLE
feat: Add support for MetadataProvider

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-log.git",
       "state" : {
-        "revision" : "6fe203dc33195667ce1759bf0182975e4653ba1c",
-        "version" : "1.4.4"
+        "revision" : "32e8d724467f8fe623624570367e3d50c5638e46",
+        "version" : "1.5.2"
       }
     }
   ],

--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/kean/pulse.git",
       "state" : {
-        "revision" : "3f13427fdc7886bb071a0979396dcd0ca4571f61",
-        "version" : "3.0.0"
+        "revision" : "3f3bbc4d7e8b96e2d37cc97d3dbc83189c709b99",
+        "version" : "3.5.2"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
         .library(name: "PulseLogHandler", targets: ["PulseLogHandler"])
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-log.git", from: "1.2.0"),
+        .package(url: "https://github.com/apple/swift-log.git", from: "1.5.2"),
         .package(url: "https://github.com/kean/pulse.git", from: "3.1.0")
     ],
     targets: [

--- a/Tests/PulseLogHandlerTests/PersistenLogHandlerTests.swift
+++ b/Tests/PulseLogHandlerTests/PersistenLogHandlerTests.swift
@@ -162,17 +162,21 @@ final class PersistentLogHandlerTests: XCTestCase {
             store: store
         )
         sut.log(level: .debug, message: "request failed")
-        sut[metadataKey: "key"] = "store-value"
         
-        // provider value overrides log handler metadata value
+        // uses provider value when present
         let message = try XCTUnwrap(store.allMessages().first)
         XCTAssertEqual(message.metadata, ["key": "provider-value"])
         
-        sut.log(level: .debug, message: "request failed", metadata: ["key": .string("entry-value")])
+        // handler metadata value overrides provider value
+        sut[metadataKey: "key"] = "store-value"
+        sut.log(level: .debug, message: "request failed")
+        let messageTwo = try XCTUnwrap(store.allMessages().last)
+        XCTAssertEqual(messageTwo.metadata, ["key": "store-value"])
         
         // log entry value overrides store and provider value
-        let messageTwo = try XCTUnwrap(store.allMessages().last)
-        XCTAssertEqual(messageTwo.metadata, ["key": "entry-value"])
+        sut.log(level: .debug, message: "request failed", metadata: ["key": .string("entry-value")])
+        let messageThree = try XCTUnwrap(store.allMessages().last)
+        XCTAssertEqual(messageThree.metadata, ["key": "entry-value"])
     }
 }
 

--- a/Tests/PulseLogHandlerTests/PersistenLogHandlerTests.swift
+++ b/Tests/PulseLogHandlerTests/PersistenLogHandlerTests.swift
@@ -45,9 +45,6 @@ final class PersistentLogHandlerTests: XCTestCase {
         let date = Date() - 200
         currentDate = date
 
-        LoggerStore.Session.startSession()
-        let sessionID = LoggerStore.Session.current.id
-
         LoggingSystem.bootstrap {
             MultiplexLogHandler([
                 PersistentLogHandler(label: $0, store: self.store),
@@ -67,15 +64,15 @@ final class PersistentLogHandlerTests: XCTestCase {
             return XCTFail("Unexpected number of messages stored")
         }
 
-        let persistedMessage1 = try XCTUnwrap(persistedMessages.first { $0.label.name == "test.logger.1" })
+        let persistedMessage1 = try XCTUnwrap(persistedMessages.first { $0.label == "test.logger.1" })
         XCTAssertEqual(persistedMessage1.text, message1)
         XCTAssertEqual(persistedMessage1.createdAt, date)
-        XCTAssertEqual(persistedMessage1.session, sessionID)
+        XCTAssertEqual(persistedMessage1.sessionID, store.sessionID)
 
-        let persistedMessage2 = try XCTUnwrap(persistedMessages.first { $0.label.name == "test.logger.2" })
+        let persistedMessage2 = try XCTUnwrap(persistedMessages.first { $0.label == "test.logger.2" })
         XCTAssertEqual(persistedMessage2.text, message2)
         XCTAssertEqual(persistedMessage2.createdAt, date)
-        XCTAssertEqual(persistedMessage2.session, sessionID)
+        XCTAssertEqual(persistedMessage2.sessionID, store.sessionID)
     }
 
     func testStoresFileInformation() throws {


### PR DESCRIPTION
swift-log now supports the concept of [metadata providers](https://github.com/apple/swift-log/pull/238) - this PR adds support for metadata providers to `PersistentLogHandler`.

* Implements new protocol requirements.
* Implements metadata merging logic - I've followed the same implementation as [console-kit](https://github.com/vapor/console-kit/pull/177) in terms of metadata priority - when conflicts arise, the log entry's metadata will take precedence, followed by the metadata set on the handler and finally the metadata returned from the provider.
* Fixed a broken test.