### PR TITLE
fix: Pass metadata provider onto initializer

### DIFF
--- a/Sources/PulseLogHandler/PersistentLogHandler.swift
+++ b/Sources/PulseLogHandler/PersistentLogHandler.swift
@@ -43,7 +43,7 @@ public struct PersistentLogHandler {
     }
     
     public init(label: String, metadataProvider: Logger.MetadataProvider?) {
-        self.init(label: label, metadataProvider: nil, store: .shared)
+        self.init(label: label, metadataProvider: metadataProvider, store: .shared)
     }
     
     public init(label: String, metadataProvider: Logger.MetadataProvider?, store: LoggerStore) {


### PR DESCRIPTION
Fixes a bug where the metadata provider was not being passed into the main initialiser.