### PR TITLE
Remove tvOS 14

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ let package = Package(
     name: "PulseLogHandler",
     platforms: [
         .iOS(.v14),
-        .tvOS(.v14),
+        .tvOS(.v15),
         .macOS(.v12),
         .watchOS(.v8)
     ],


### PR DESCRIPTION
Pulse removed tvOS 14 support [here](https://github.com/kean/Pulse/commit/da0aa339e45b72b3c4b37ae58f9e7a69ca7e6821). Reflect here to compile correctly.