### PR TITLE
fix(swift-package): Fix Minimum Versions

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,7 @@ let package = Package(
     platforms: [
         .iOS(.v15),
         .tvOS(.v15),
-        .macOS(.v12),
+        .macOS(.v13),
         .watchOS(.v9)
     ],
     products: [

--- a/Package.swift
+++ b/Package.swift
@@ -8,7 +8,7 @@ let package = Package(
         .iOS(.v15),
         .tvOS(.v15),
         .macOS(.v12),
-        .watchOS(.v8)
+        .watchOS(.v9)
     ],
     products: [
         .library(name: "PulseLogHandler", targets: ["PulseLogHandler"])


### PR DESCRIPTION
Pulse has a minimum required watchOS version of 9 and a minimum macOS version of 13. Adding this package causes a project to fail to build due to the mismatch of versions.